### PR TITLE
cabal: only add build-depends if needed

### DIFF
--- a/ascii-progress.cabal
+++ b/ascii-progress.cabal
@@ -38,22 +38,29 @@ library
 
 executable example
   main-is:             Example.hs
-  build-depends:       ansi-terminal
+  default-language:    Haskell2010
+
+  if !flag(examples)
+    buildable: False
+  else
+    buildable: True
+    build-depends:     ansi-terminal
                      , async >= 2.0.1.5
                      , base >=4 && <5
                      , data-default >= 0.5.3
                      , time >= 1.4.2
-  hs-source-dirs:      lib
+    hs-source-dirs:    lib
                      , bin
-  if flag(examples)
-   buildable: True
-  else
-   buildable: False
-  default-language:    Haskell2010
 
 executable download-example
   main-is:             DownloadExample.hs
-  build-depends:       HTTP
+  default-language:    Haskell2010
+
+  if !flag(examples)
+    buildable: False
+  else
+    buildable: True
+    build-depends:     HTTP
                      , ansi-terminal
                      , async >= 2.0.1.5
                      , base >=4 && <5
@@ -64,28 +71,24 @@ executable download-example
                      , http-conduit >= 2.1
                      , http-types >= 0.8
                      , transformers >= 0.3
-  hs-source-dirs:      lib
+    hs-source-dirs:    lib
                      , bin
-  if flag(examples)
-   buildable: True
-  else
-   buildable: False
-  default-language:    Haskell2010
 
 executable multi-example
   main-is:             MultiExample.hs
-  build-depends:       ansi-terminal
+  default-language:    Haskell2010
+
+  if !flag(examples)
+    buildable: False
+  else
+    buildable: True
+    build-depends:     ansi-terminal
                      , async >= 2.0.1.5
                      , base >=4 && <5
                      , data-default >= 0.5.3
                      , time >= 1.4.2
-  hs-source-dirs:      lib
+    hs-source-dirs:    lib
                      , bin
-  if flag(examples)
-   buildable: True
-  else
-   buildable: False
-  default-language:    Haskell2010
 
 test-suite hspec
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Currently, the dependencies for the examples are required, even if the
examples are not build:

    $ runhaskell Setup configure --flags=-examples
    Configuring ascii-progress-0.2.1.2...
    Setup: At least the following dependencies are missing:
    HTTP -any, conduit >=1.2, http-conduit >=2.1, http-types >=0.8

This patch modifies the cabal file such that the dependencies are only
added if the examples are build.