### PR TITLE
ascii-progress.cabal: include hspec-discover as build tool

### DIFF
--- a/ascii-progress.cabal
+++ b/ascii-progress.cabal
@@ -128,6 +128,7 @@ executable crazy-multi-example
 test-suite hspec
   type:                exitcode-stdio-1.0
   main-is: Spec.hs
+  build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       concurrent-output >= 1.7
                      , async >= 2.0.1.5
                      , base >=4 && <5


### PR DESCRIPTION
It is technically required to run the tests.